### PR TITLE
chore: renovate設定にtimezone/schedule/labels/packageRulesを追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,35 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "labels": ["dependencies"],
+  "ignorePaths": [
+    ".github/workflows/release.yml"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge patch / pin / digest updates after CI passes",
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "NUnit family",
+      "groupName": "nunit",
+      "matchPackageNames": ["NUnit", "NUnit3TestAdapter", "NUnit.Analyzers"]
+    },
+    {
+      "description": "Test infrastructure",
+      "groupName": "test-infra",
+      "matchPackageNames": ["Microsoft.NET.Test.Sdk", "coverlet.collector"]
+    },
+    {
+      "description": "GitHub Actions",
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- `timezone: Asia/Tokyo` + `schedule: before 9am on monday` で毎週月曜朝9時前（JST）に更新チェック
- `labels: ["dependencies"]` で依存更新PRを識別しやすく
- `ignorePaths` で `release.yml` を除外（リリースワークフローは手動管理）
- `packageRules` でpatch/pin/digestをCI通過後に自動マージ、NuGetパッケージとGitHub Actionsをグループ化

## Test plan

- [ ] `renovate.json` のJSONスキーマが正しいことを確認
- [ ] 次の月曜朝9時（JST）以降にRenovateがPRを作成することを確認
- [ ] 作成されたPRに `dependencies` ラベルが付いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)