### PR TITLE
chore(deps): actions/download-artifact を v4 から v8 に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       
     - name: Download all artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         path: ./artifacts
         


### PR DESCRIPTION
## Summary

- `release.yml` の `actions/download-artifact` を v4 → v8 に更新
- Node.js 20 deprecation 対応 (強制移行: 2026-06-02)
- upload-artifact v7 (PR #27 でマージ済み) と同一ランタイム系列に統一

## 互換性確認

現在の使い方:
```yaml
uses: actions/download-artifact@v8
with:
  path: ./artifacts
```

- v5 破壊的変更 (`artifact-ids` 指定時のパス構造変更) → `artifact-ids` 未使用のため非該当
- v8 破壊的変更 (ダイジェスト不一致エラー化) → 正常な artifact 転送では問題なし

## Test plan

- [ ] CI (`Build and Test`) がグリーン
- [ ] release.yml は tag push でのみ動作するため、手動での確認が必要な場合は workflow_dispatch で試走

🤖 Generated with [Claude Code](https://claude.com/claude-code)